### PR TITLE
[*] bugfix to hoisting variable

### DIFF
--- a/install.js
+++ b/install.js
@@ -7,13 +7,14 @@ const HOME = require('os').homedir()
 const PROFILE_PATH = HOME + path.sep + '.bash_profile'
 
 let SOURCE_COMMAND = '\n  source ' + __dirname + path.sep + 'index.sh'
+let SOURCE_COMMAND_STR = `
+# Pointing bash_profile to load profiler js${SOURCE_COMMAND};
+`
 
 try {
     const bashProfileContent = fs.readFileSync(PROFILE_PATH, 'utf8').toString()
     if (bashProfileContent.indexOf(SOURCE_COMMAND) < 0) {
-        let SOURCE_COMMAND_STR = `
-# Pointing bash_profile to load profiler js${SOURCE_COMMAND};
-`
+        
         execSync(`echo "${SOURCE_COMMAND_STR}" >> ${PROFILE_PATH}`)
 
         const l = Math.max(60, SOURCE_COMMAND.length + 2)


### PR DESCRIPTION
## DESCRIPTION
The reason it is the hoisting, the variable __SOURCE_COMMAND_STR__ it was been declared at try scope, in the catch scope it was not setted.

![screenshot from 2018-02-08 01-27-12](https://user-images.githubusercontent.com/3317013/35954165-4e230f7e-0c6f-11e8-913a-9fd192c279f5.png)
