### PR TITLE
[*] linux aliases review

### DIFF
--- a/aliases.sh
+++ b/aliases.sh
@@ -187,7 +187,7 @@ alias down='cd ~/Downloads'
 alias amionline="ping www.google.com -c 1 2>/dev/null >/dev/null && echo \"Yes\" || echo \"No\""
 alias amioffline="ping www.google.com -c 1 2>/dev/null >/dev/null && echo \"No\" || echo \"Yes\""
 
-alias ifactive="ifconfig | pcregrep -M -o '^[^\t:]+:([^\n]|\n\t)*status: active'"
+alias ifactive="sudo ifconfig | try pcregrep -M -o '^[^\t:]+:([^\n]|\n\t)*status: active'"
 alias flush="dscacheutil -flushcache && killall -HUP mDNSResponder"
 # Empty the Trash on all mounted volumes and the main HDD
 alias emptytrash="sudo rm -rfv /Volumes/*/.Trashes; sudo rm -rfv ~/.Trash;"

--- a/aliases.sh
+++ b/aliases.sh
@@ -6,7 +6,8 @@
 
 # if test "$(uname)" = "Darwin" ; then
 function try () {
-    # echo `command -v foo >/dev/null 2>&1 || echo >&2 "The command $1 is not installed $2"; exit 1`
+    # echo `command -v foo >/dev/null 2>&1 || echo >&2
+    # "The command $1 is not installed $2"; exit 1`
     local apt=`command -v apt-get`
     local yum=`command -v yum`
     local brew=`command -v brew`
@@ -94,7 +95,7 @@ function try () {
 alias fixcamera="sudo killall VDCAssistant"
 # your IP in the local network
 # alias ipin="try -qe ipconfig getifaddr en0 "
-alias ipin="ifconfig | sed -En 's/127.0.0.1//;s/.*inet (addr:)?(([0-9]*\.){3}[0-9]*).*/\2/p'"
+alias ipin="sudo ifconfig | sed -En 's/127.0.0.1//;s/.*inet (addr:)?(([0-9]*\.){3}[0-9]*).*/\2/p'"
 # your IP seen from outside
 alias ipout='dig +short myip.opendns.com @resolver1.opendns.com 2>/dev/null || echo "No internet connection"'
 # more information about your ip

--- a/aliases.sh
+++ b/aliases.sh
@@ -6,8 +6,7 @@
 
 # if test "$(uname)" = "Darwin" ; then
 function try () {
-    # echo `command -v foo >/dev/null 2>&1 || echo >&2
-    # "The command $1 is not installed $2"; exit 1`
+    # echo `command -v foo >/dev/null 2>&1 || echo >&2 "The command $1 is not installed $2"; exit 1`
     local apt=`command -v apt-get`
     local yum=`command -v yum`
     local brew=`command -v brew`
@@ -150,7 +149,7 @@ function doubleline () {
 alias sizes="sudo du -cxhd 1"
 alias flushDNS='dscacheutil -flushcache'
 alias DSFiles_removal="find . -type f -name '*.DS_Store' -ls -delete"
-alias hosts_edit='sudo vim /etc/hosts'
+alias hosts_edit='sudo vi /etc/hosts'
 alias reloadprofiler='source ~/.bash_profile'
 alias reload="exec ${SHELL} -l"
 # alias reload="tset 2>/dev/null || reset"

--- a/aliases.sh
+++ b/aliases.sh
@@ -162,6 +162,7 @@ function hostedit() {
 }
 alias hosts_edit=hostedit
 alias reloadprofiler='source ~/.bash_profile'
+alias reloadbashrc='source ~/.bashrc'
 alias reload="exec ${SHELL} -l"
 # alias reload="tset 2>/dev/null || reset"
 alias h='history'

--- a/aliases.sh
+++ b/aliases.sh
@@ -151,10 +151,10 @@ alias flushDNS='dscacheutil -flushcache'
 alias DSFiles_removal="find . -type f -name '*.DS_Store' -ls -delete"
 
 
-function hostedit() {
-    local apt=`command -v vim`
+function hostsedit() {
+    viim=`command -v vim`
 
-    if [ -n $vim ]; then
+    if [ $viim ]; then
         sudo vim /etc/hosts
     else
         sudo vi /etc/hosts

--- a/aliases.sh
+++ b/aliases.sh
@@ -149,7 +149,18 @@ function doubleline () {
 alias sizes="sudo du -cxhd 1"
 alias flushDNS='dscacheutil -flushcache'
 alias DSFiles_removal="find . -type f -name '*.DS_Store' -ls -delete"
-alias hosts_edit='sudo vi /etc/hosts'
+
+
+function hostedit() {
+    local apt=`command -v vim`
+
+    if [ -n $vim ]; then
+        sudo vim /etc/hosts
+    else
+        sudo vi /etc/hosts
+    fi
+}
+alias hosts_edit=hostedit
 alias reloadprofiler='source ~/.bash_profile'
 alias reload="exec ${SHELL} -l"
 # alias reload="tset 2>/dev/null || reset"

--- a/aliases.sh
+++ b/aliases.sh
@@ -171,7 +171,7 @@ if [ -n "now" ]; then
     alias now='date +"%T"'
 fi
 alias ports='netstat -tulanp'
-alias lsd='ll | grep "^d" --colors=never' # ls for only directories
+alias lsd='ll | grep "^d" --color=never' # ls for only directories
 alias lsf='ll | grep "^[^d]" --color=no' # ls for only files
 alias grep='grep --color=auto'
 alias fgrep='fgrep --color=auto'


### PR DESCRIPTION
## CHANGED
- __ipin__
    - ifconfig should be performed with root previlegious, at debian the local ifconfig dont exist
- __hosts_edit__
    - created function to verify VIM installation, use VI case VIM missing
- __lsd__
    - --color is the valid param, --colors is invalid param

## ADDED
- __reloadbashrc__
    - following the reloadprofiler logic


## PROBLEM
- __flush__ and __flushDNS__ is not running
    - the reason is that dscacheutil - it is a apple development
- __amioffline/amionline__: always offline returning Yes and amionline No, the same whithout connection
- __ifactive__
    - pcregrep: Failed to open active: No such file or directory
- __pbcopy__
    - pbcoy it is to OS, to Debian/UBUNTU etc you should to use:

``` bash
sudo apt-get install xclip

# to create alias to pbcpy 
alias pbcopy='xclip -selection clipboard'
alias pbpaste='xclip -selection clipboard -o'
# now you are able to use the pbcopy to linux
```

- __datauri__
``` bash
bash: pbcopy: command not found
=> data URI copied to pasteboard.
base64: Cannot open input file , No such file or directory
base64: Use -help for summary.
```


## QUESTION
``` bash
alias ff='find . -not -path "*/node_modules/*" -not -path "*.git/*" -type f -iname '
alias findfile='ff'
alias fd='find . -not -path "*/node_modules/*" -not -path "*.git/*" -type d -iname '
alias finddir='fd'
```

The commands above, what should to happen? Maybe I mistake to run, findfile and finddir broke the terminal.

- __md5sum / shasum:__
   - i dont know what to to with that
